### PR TITLE
Fix vk links matching

### DIFF
--- a/vktgbot/tools.py
+++ b/vktgbot/tools.py
@@ -80,7 +80,7 @@ def split_text(text: str, fragment_size: int) -> list:
 
 
 def reformat_vk_links(text: str) -> str:
-    match = re.search("\[(.+?)\|(.+?)\]", text)
+    match = re.search("\[([\w.]+?)\|(.+?)\]", text)
     while match:
         left_text = text[: match.span()[0]]
         right_text = text[match.span()[1] :]
@@ -88,6 +88,6 @@ def reformat_vk_links(text: str) -> str:
 
         link_domain, link_text = re.findall("\[(.+?)\|(.+?)\]", matching_text)[0]
         text = left_text + f"""<a href="{f'https://vk.com/{link_domain}'}">{link_text}</a>""" + right_text
-        match = re.search("\[(.+?)\|(.+?)\]", text)
+        match = re.search("\[([\w.]+?)\|(.+?)\]", text)
 
     return text


### PR DESCRIPTION
Регулярка некорректно отлавливала ссылки, как например в подобном:
`Текст [ [id123|Имя], текст :) ] текст`
за ссылку считалось `[ [id123|Имя]` вместо `[id123|Имя]`, ибо захват абсолютно всего от первой скобки, и пока не встретится символ «|», ошибочно считался корректным.

Исправление с учётом допустимых символов для адреса страниц — латинских букв, цифр, нижнего подчёркивания и точки.